### PR TITLE
Add pack-mac script

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "pack-win-test": "electron-builder --dir --win",
     "pack-linux-test": "electron-builder --dir --linux",
     "pack-linux": "electron-builder --linux",
+    "pack-mac": "electron-builder --mac",
     "publish": "electron-builder --win -p always",
     "publish-linux": "electron-builder --linux -p always",
     "postinstall": "electron-builder install-app-deps",


### PR DESCRIPTION
Hi Charles 👋 

For some reason I could not run the latest release on my mac: 0.8.92

![Error on mac](https://user-images.githubusercontent.com/226834/113420328-7f508a80-939f-11eb-99c6-13ff6bfd7e7e.png)

I was able to pack it locally, and then it worked. Running the newly added `npm pack-mac` did the trick.