### PR TITLE
Fix freedesktop category (Utilities → Utility)

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
       ]
     },
     "linux": {
-      "category": "Utilities",
+      "category": "Utility",
       "target": "AppImage",
       "icon": "build/icon.png",
       "publish": [


### PR DESCRIPTION
According to the freedesktop.org specification[1] proper name for utilities category is "Utility".

[1] https://specifications.freedesktop.org/menu-spec/latest/apa.html